### PR TITLE
Added volatile keyword to address for union read

### DIFF
--- a/mbed-hal-k64f/device/MK64F12/fsl_bitaccess.h
+++ b/mbed-hal-k64f/device/MK64F12/fsl_bitaccess.h
@@ -114,7 +114,7 @@
 #endif
 
 #ifndef UNION_READ
-#define UNION_READ(type, addr, fieldU, fieldB) ((*((type *) (addr))).fieldB)
+#define UNION_READ(type, addr, fieldU, fieldB) ((*((volatile type *) (addr))).fieldB)
 #endif
 
 /*


### PR DESCRIPTION
It was used originally and mistakenly removed when defining the new macro
`UNION_READ`
