### PR TITLE
Update startup_MK64F12.S

### DIFF
--- a/source/bootstrap_gcc/startup_MK64F12.S
+++ b/source/bootstrap_gcc/startup_MK64F12.S
@@ -4,6 +4,9 @@
  * Version: V1.2
  * Date: 15 Nov 2011
  *
+ * Copyright (c) 1997 - 2011 Freescale Semiconductor, Inc. 
+ * All Rights Reserved.
+ *
  * Copyright (c) 2011, ARM Limited
  * All rights reserved.
  *


### PR DESCRIPTION
This file is a derived work from KSDK (eg. all the interrupt handler functions have the same names) but it does not have Freescale Copyright statement.  Surmise whoever in mbed did this work back in 2011 did not have the same interpretation of what counts as a "derived work" as we do now.  I have added back a Fresscale copyright statement.
