### PR TITLE
Restore proper license on startup file

### DIFF
--- a/source/bootstrap_armcc/startup_MK64F12.s
+++ b/source/bootstrap_armcc/startup_MK64F12.s
@@ -1,11 +1,39 @@
-;/*****************************************************************************
-; * @file:    startup_MK70F12.s
-; * @purpose: CMSIS Cortex-M4 Core Device Startup File for the
-; *           MK70F12
-; * @version: 1.5
-; * @date:    2012-10-19
+; * ---------------------------------------------------------------------------------------
+; *  @file:    startup_MK64F12.s
+; *  @purpose: CMSIS Cortex-M4 Core Device Startup File
+; *            MK64F12
+; *  @version: 2.8
+; *  @date:    2015-2-19
+; *  @build:   b150225
+; * ---------------------------------------------------------------------------------------
 ; *
-; * Copyright: 1997 - 2012 Freescale Semiconductor, Inc. All Rights Reserved.
+; * Copyright (c) 1997 - 2015 , Freescale Semiconductor, Inc.
+; * All rights reserved.
+; *
+; * Redistribution and use in source and binary forms, with or without modification,
+; * are permitted provided that the following conditions are met:
+; *
+; * o Redistributions of source code must retain the above copyright notice, this list
+; *   of conditions and the following disclaimer.
+; *
+; * o Redistributions in binary form must reproduce the above copyright notice, this
+; *   list of conditions and the following disclaimer in the documentation and/or
+; *   other materials provided with the distribution.
+; *
+; * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+; *   contributors may be used to endorse or promote products derived from this
+; *   software without specific prior written permission.
+; *
+; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+; * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+; * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+; * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+; * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+; * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+; * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+; * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+; * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+; * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;*
 ; *------- <<< Use Configuration Wizard in Context Menu >>> ------------------
 ; *


### PR DESCRIPTION
It looks like our original ARMCC startup file came from an older version of
K(P)SDK and didn't have any license. However, the file is very similar to the
corresponding file in KSDK 1.2.0, so this commit changes the license to
match the one in KSDK (and the license of the rest of files from KSDK
from this module).
