### PR TITLE
Bumped dependency version on uvisor-lib

### DIFF
--- a/module.json
+++ b/module.json
@@ -31,7 +31,7 @@
   },
   "targetDependencies": {
     "gcc": {
-      "uvisor-lib": "~0.7.0"
+      "uvisor-lib": "~0.8.0"
     },
     "frdm-k64f": {
       "mbed-hal-frdm-k64f": "~0.4.0"


### PR DESCRIPTION
Requires https://github.com/ARMmbed/target-frdm-k64f-gcc/pull/11 to bu merged, bumped and published
@bremoran @0xc0170 @autopulated 