### PR TITLE
Module - extraInclude mbed-hal to be compatible with legacy targets

### DIFF
--- a/module.json
+++ b/module.json
@@ -22,6 +22,7 @@
     }
   ],
   "extraIncludes": [
+    "mbed-hal",
     "mbed-hal-k64f",
     "mbed-hal-k64f/device",
     "mbed-hal-k64f/MK64F12"


### PR DESCRIPTION
As most of the code includes just "PinNames.h", to be compatible with this legacy header added yesterday.

I'll create action item to switch to new GeneratedPinnames
@bremoran @bogdanm 