### PR TITLE
Updated dependency on latest uvisor-lib

### DIFF
--- a/module.json
+++ b/module.json
@@ -32,7 +32,7 @@
   },
   "targetDependencies": {
     "gcc": {
-      "uvisor-lib": "^1.0.0"
+      "uvisor-lib": ">=1.0.0,<3.0.0"
     },
     "frdm-k64f": {
       "mbed-hal-frdm-k64f": "^1.0.0"


### PR DESCRIPTION
uvisor-lib 2.0.0 was just released. This commit updates the dependency
on uvisor-lib to take into account this version.